### PR TITLE
fix: goTo command

### DIFF
--- a/src/commands/goTo.ts
+++ b/src/commands/goTo.ts
@@ -21,7 +21,7 @@ export class GoToCommand extends AbstractCommandNoResponse {
 		}
 
 		if (this.clip !== undefined) res.params.clip = this.clip
-		if (this.clipId !== undefined) res.params.clipId = this.clipId + ''
+		if (this.clipId !== undefined) res.params['clip id'] = this.clipId + ''
 		if (this.timecode !== undefined) res.params.timecode = this.timecode
 
 		if (Object.keys(res.params).length === 0) {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
When trying to goTo a clip id the hyperdeck would return an error.
console.log(res)
`{ name: 'goto', params: { clipId: '1' } }`
Debug
`sending str: goto:`
`clipId: 1`
Response from Hyperdeck
`{ code: 100, name: 'syntax error', params: {} }`

* **What is the new behavior (if this is a feature change)?**
goTo clip id now works.
console.log(res)
`{ name: 'goto', params: { 'clip id': '1' } }`
Debug
`sending str: goto:`
`clip id: 1`
Response from Hyperdeck
`res { code: 200, name: 'ok', params: {} }`


* **Other information**:
