### PR TITLE
Corrected shuttle command

### DIFF
--- a/src/commands/shuttle.ts
+++ b/src/commands/shuttle.ts
@@ -12,7 +12,7 @@ export class ShuttleCommand extends AbstractCommandNoResponse {
 
 	serialize () {
 		const res: NamedMessage = {
-			name: 'speed',
+			name: 'shuttle',
 			params: {}
 		}
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Shuttle command return a 100 syntax error. Debugging showed that the command being sent was `speed: speed: [xxx]` where it should be `shuttle: speed: [xxx]`

* **What is the new behavior (if this is a feature change)?**

Should now send the correct `shuttle: speed: [xxx}` command

* **Other information**:
