### PR TITLE
Support v1.11 configuration options

### DIFF
--- a/src/asyncHandlers/configuration.ts
+++ b/src/asyncHandlers/configuration.ts
@@ -6,6 +6,14 @@ export interface ConfigurationChangeResponse {
 	audioInput?: 'embedded' | 'XLR' | 'RCA'
 	videoInput?: 'SDI' | 'HDMI' | 'component' | string
 	fileFormat?: string
+	// v1.11:
+    audioCodec?: 'PCM' | 'AAC';
+    timecodeInput?: 'external' | 'embedded' | 'preset' | 'clip';
+    timecodePreset?: string;
+    audioInputChannels?: number;
+    recordTrigger?: 'none' | 'recordbit' | 'timecoderun';
+    recordPrefix?: string;
+    appendTimestamp?: boolean;
 }
 
 export class ConfigurationChange implements IHandler {
@@ -17,6 +25,14 @@ export class ConfigurationChange implements IHandler {
 			audioInput: msg.params['audio input'] as ConfigurationChangeResponse['audioInput'],
 			videoInput: msg.params['video input'] as ConfigurationChangeResponse['videoInput'],
 			fileFormat: msg.params['file format'] as ConfigurationChangeResponse['fileFormat'],
+			// v1.11 optional props:
+			audioCodec: msg.params['audio codec'] as ConfigurationCommandResponse['audioCodec'],
+			timecodeInput: msg.params['timecode input'] as ConfigurationCommandResponse['timecodeInput'],
+			timecodePreset: msg.params['timecode preset'] as ConfigurationCommandResponse['timecodePreset'],
+			audioInputChannels: msg.params['audio input'] ? parseInt(msg.params['audio input channels']) : undefined,
+			recordTrigger: msg.params['record trigger'] as ConfigurationCommandResponse['recordTrigger'],
+			recordPrefix: msg.params['record prefix'] as ConfigurationCommandResponse['recordPrefix'],
+			appendTimestamp: msg.params['append timestamp'] ? msg.params['append timestamp'] === 'true' : undefined,
 		}
 		return res
 	}

--- a/src/asyncHandlers/configuration.ts
+++ b/src/asyncHandlers/configuration.ts
@@ -7,13 +7,13 @@ export interface ConfigurationChangeResponse {
 	videoInput?: 'SDI' | 'HDMI' | 'component' | string
 	fileFormat?: string
 	// v1.11:
-    audioCodec?: 'PCM' | 'AAC';
-    timecodeInput?: 'external' | 'embedded' | 'preset' | 'clip';
-    timecodePreset?: string;
-    audioInputChannels?: number;
-    recordTrigger?: 'none' | 'recordbit' | 'timecoderun';
-    recordPrefix?: string;
-    appendTimestamp?: boolean;
+	audioCodec?: 'PCM' | 'AAC';
+	timecodeInput?: 'external' | 'embedded' | 'preset' | 'clip';
+	timecodePreset?: string;
+	audioInputChannels?: number;
+	recordTrigger?: 'none' | 'recordbit' | 'timecoderun';
+	recordPrefix?: string;
+	appendTimestamp?: boolean;
 }
 
 export class ConfigurationChange implements IHandler {

--- a/src/asyncHandlers/configuration.ts
+++ b/src/asyncHandlers/configuration.ts
@@ -26,12 +26,12 @@ export class ConfigurationChange implements IHandler {
 			videoInput: msg.params['video input'] as ConfigurationChangeResponse['videoInput'],
 			fileFormat: msg.params['file format'] as ConfigurationChangeResponse['fileFormat'],
 			// v1.11 optional props:
-			audioCodec: msg.params['audio codec'] as ConfigurationCommandResponse['audioCodec'],
-			timecodeInput: msg.params['timecode input'] as ConfigurationCommandResponse['timecodeInput'],
-			timecodePreset: msg.params['timecode preset'] as ConfigurationCommandResponse['timecodePreset'],
+			audioCodec: msg.params['audio codec'] as ConfigurationChangeResponse['audioCodec'],
+			timecodeInput: msg.params['timecode input'] as ConfigurationChangeResponse['timecodeInput'],
+			timecodePreset: msg.params['timecode preset'] as ConfigurationChangeResponse['timecodePreset'],
 			audioInputChannels: msg.params['audio input'] ? parseInt(msg.params['audio input channels']) : undefined,
-			recordTrigger: msg.params['record trigger'] as ConfigurationCommandResponse['recordTrigger'],
-			recordPrefix: msg.params['record prefix'] as ConfigurationCommandResponse['recordPrefix'],
+			recordTrigger: msg.params['record trigger'] as ConfigurationChangeResponse['recordTrigger'],
+			recordPrefix: msg.params['record prefix'] as ConfigurationChangeResponse['recordPrefix'],
 			appendTimestamp: msg.params['append timestamp'] ? msg.params['append timestamp'] === 'true' : undefined,
 		}
 		return res

--- a/src/asyncHandlers/configuration.ts
+++ b/src/asyncHandlers/configuration.ts
@@ -7,13 +7,13 @@ export interface ConfigurationChangeResponse {
 	videoInput?: 'SDI' | 'HDMI' | 'component' | string
 	fileFormat?: string
 	// v1.11:
-	audioCodec?: 'PCM' | 'AAC';
-	timecodeInput?: 'external' | 'embedded' | 'preset' | 'clip';
-	timecodePreset?: string;
-	audioInputChannels?: number;
-	recordTrigger?: 'none' | 'recordbit' | 'timecoderun';
-	recordPrefix?: string;
-	appendTimestamp?: boolean;
+	audioCodec?: 'PCM' | 'AAC'
+	timecodeInput?: 'external' | 'embedded' | 'preset' | 'clip'
+	timecodePreset?: string
+	audioInputChannels?: number
+	recordTrigger?: 'none' | 'recordbit' | 'timecoderun'
+	recordPrefix?: string
+	appendTimestamp?: boolean
 }
 
 export class ConfigurationChange implements IHandler {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds support to the Configuration async handler for v 1.11 options, in line with the Configuration sync command.

* **What is the current behavior?** (You can also link to an open issue here)

All responses other than the original 3 are ignored.

* **What is the new behavior (if this is a feature change)?**

All options are passed upstream.

* **Other information**:
