### PR TITLE
fix: parse all clip info from the "disk list" command into separate fields

### DIFF
--- a/src/commands/diskList.ts
+++ b/src/commands/diskList.ts
@@ -3,9 +3,23 @@ import { SlotId } from '../enums'
 import { NamedMessage, ResponseMessage } from '../message'
 import { AbstractCommand } from './abstractCommand'
 
+const deserializeRegex = /(?<fileName>.+) (?<codec>\w+) (?<format>\w+) (?<timecode>[\d:]+)$/i
+const framerateRegex = /\d+[ip](?<frameRate>\d+)/i
+const timecodeRegex = /(?<hours>\d+):(?<minutes>\d+):(?<seconds>\d+):(?<frames>\d+)/i
+
 export interface Clip {
+	/** 1, 2, 3, etc */
 	clipId: string
+	/** ExampleVideo.mov, etc */
 	name: string
+	/** QuickTimeProRes, etc */
+	codec: string
+	/** 1080i50, 720p60, etc */
+	format: string
+	/** hh:mm:ss:ff */
+	timecode: string
+	/** milliseconds */
+	duration: number
 }
 
 export interface DiskListCommandResponse {
@@ -25,14 +39,33 @@ export class DiskListCommand extends AbstractCommand {
 
 	deserialize(msg: ResponseMessage): DiskListCommandResponse {
 		const clipIds = Object.keys(msg.params).filter((x) => x !== 'slot id')
-		const clips = clipIds.map((x) => {
-			const clip: Clip = {
-				clipId: x,
-				name: msg.params[x],
-			}
+		const clips = clipIds
+			.map((x) => {
+				const match = msg.params[x].match(deserializeRegex)
+				const frameRateMatch = match?.groups?.format.match(framerateRegex)
+				const timecodeMatch = match?.groups?.timecode.match(timecodeRegex)
+				if (match?.groups && frameRateMatch?.groups && timecodeMatch?.groups) {
+					const frameRate = parseInt(frameRateMatch.groups.frameRate, 10)
+					const msPerFrame = 1000 / frameRate
+					const hoursMs = parseInt(timecodeMatch.groups.hours, 10) * 60 * 60 * 1000
+					const minutesMs = parseInt(timecodeMatch.groups.minutes, 10) * 60 * 1000
+					const secondsMs = parseInt(timecodeMatch.groups.seconds, 10) * 1000
+					const framesMs = parseInt(timecodeMatch.groups.frames) * msPerFrame
+					const clip: Clip = {
+						clipId: x,
+						name: match.groups.fileName,
+						codec: match.groups.codec,
+						format: match.groups.format,
+						timecode: match.groups.timecode,
+						duration: hoursMs + minutesMs + secondsMs + framesMs,
+					}
 
-			return clip
-		})
+					return clip
+				}
+
+				return undefined
+			})
+			.filter((clip): clip is Clip => Boolean(clip))
 
 		const res: DiskListCommandResponse = {
 			slotId: parseInt(msg.params['slot id'], 10),

--- a/src/commands/diskList.ts
+++ b/src/commands/diskList.ts
@@ -45,9 +45,11 @@ export class DiskListCommand extends AbstractCommand {
 				const frameRateMatch = match?.groups?.format.match(framerateRegex)
 				const timecodeMatch = match?.groups?.timecode.match(timecodeRegex)
 				if (match?.groups && frameRateMatch?.groups && timecodeMatch?.groups) {
+					// according to the manual, timecodes are expressed as non-drop-frame
 					const interlaced = frameRateMatch.groups.scan.toLowerCase() === 'i'
-					const fieldRate = parseInt(frameRateMatch.groups.frameRate, 10)
-					const msPerFrame = 1000 / (interlaced ? fieldRate / 2 : fieldRate)
+					const rawFrameRate = parseInt(frameRateMatch.groups.frameRate, 10)
+					const frameRate = Math.round(interlaced ? rawFrameRate / 2 : rawFrameRate)
+					const msPerFrame = 1000 / (interlaced ? frameRate / 2 : frameRate)
 					const hoursMs = parseInt(timecodeMatch.groups.hours, 10) * 60 * 60 * 1000
 					const minutesMs = parseInt(timecodeMatch.groups.minutes, 10) * 60 * 1000
 					const secondsMs = parseInt(timecodeMatch.groups.seconds, 10) * 1000

--- a/src/commands/diskList.ts
+++ b/src/commands/diskList.ts
@@ -4,7 +4,7 @@ import { NamedMessage, ResponseMessage } from '../message'
 import { AbstractCommand } from './abstractCommand'
 
 const deserializeRegex = /(?<fileName>.+) (?<codec>\w+) (?<format>\w+) (?<timecode>[\d:]+)$/i
-const framerateRegex = /\d+[ip](?<frameRate>\d+)/i
+const framerateRegex = /\d+(?<scan>[ip])(?<frameRate>\d+)/i
 const timecodeRegex = /(?<hours>\d+):(?<minutes>\d+):(?<seconds>\d+):(?<frames>\d+)/i
 
 export interface Clip {
@@ -45,8 +45,9 @@ export class DiskListCommand extends AbstractCommand {
 				const frameRateMatch = match?.groups?.format.match(framerateRegex)
 				const timecodeMatch = match?.groups?.timecode.match(timecodeRegex)
 				if (match?.groups && frameRateMatch?.groups && timecodeMatch?.groups) {
-					const frameRate = parseInt(frameRateMatch.groups.frameRate, 10)
-					const msPerFrame = 1000 / frameRate
+					const interlaced = frameRateMatch.groups.scan.toLowerCase() === 'i'
+					const fieldRate = parseInt(frameRateMatch.groups.frameRate, 10)
+					const msPerFrame = 1000 / (interlaced ? fieldRate / 2 : fieldRate)
 					const hoursMs = parseInt(timecodeMatch.groups.hours, 10) * 60 * 60 * 1000
 					const minutesMs = parseInt(timecodeMatch.groups.minutes, 10) * 60 * 1000
 					const secondsMs = parseInt(timecodeMatch.groups.seconds, 10) * 1000


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix or a feature, depending on how you look at it...

* **What is the current behavior?** (You can also link to an open issue here)

The `disk list` command returns information like this:

```
disk list
206 disk list:
slot id: 1
1: Blackmagic HyperDeck Studio Mini[0000].mov QuickTimeProRes 1080i50 03:43:22:03
2: Blackmagic HyperDeck Studio Mini[0001].mov QuickTimeProRes 1080i50 00:35:07:21
3: HyperDeck_0006.mov QuickTimeProRes 1080i50 00:00:19:08
4: HyperDeck_0007.mov QuickTimeProRes 1080i50 00:00:04:12
5: HyperDeck_0008.mov QuickTimeProRes 1080i50 00:00:05:16
6: HyperDeck_0009.mov QuickTimeProRes 1080i50 00:00:00:24
7: HyperDeck_0010.mov QuickTimeProRes 1080i50 00:00:09:13
8: HyperDeck_0011.mov QuickTimeProRes 1080i50 00:09:13:11
9: HyperDeck_0012.mov QuickTimeProRes 1080i50 00:00:14:11
10: HyperDeck_0013.mov QuickTimeProRes 1080i50 00:10:50:17
```

... which, currently, `hyperdeck-connection` parses like this:

```
response: {
  "slotId": 1,
  "clips": [
    {
      "clipId": "1",
      "name": "Blackmagic HyperDeck Studio Mini[0000].mov QuickTimeProRes 1080i50 03:43:22:03"
    },
    {
      "clipId": "2",
      "name": "Blackmagic HyperDeck Studio Mini[0001].mov QuickTimeProRes 1080i50 00:35:07:21"
    },
    {
      "clipId": "3",
      "name": "HyperDeck_0006.mov QuickTimeProRes 1080i50 00:00:19:08"
    },
    {
      "clipId": "4",
      "name": "HyperDeck_0007.mov QuickTimeProRes 1080i50 00:00:04:12"
    },
    {
      "clipId": "5",
      "name": "HyperDeck_0008.mov QuickTimeProRes 1080i50 00:00:05:16"
    },
    {
      "clipId": "6",
      "name": "HyperDeck_0009.mov QuickTimeProRes 1080i50 00:00:00:24"
    },
    {
      "clipId": "7",
      "name": "HyperDeck_0010.mov QuickTimeProRes 1080i50 00:00:09:13"
    },
    {
      "clipId": "8",
      "name": "HyperDeck_0011.mov QuickTimeProRes 1080i50 00:09:13:11"
    },
    {
      "clipId": "9",
      "name": "HyperDeck_0012.mov QuickTimeProRes 1080i50 00:00:14:11"
    },
    {
      "clipId": "10",
      "name": "HyperDeck_0013.mov QuickTimeProRes 1080i50 00:10:50:17"
    }
  ]
```

... which doesn't seem accurate. There's multiple pieces of data shoved into the `name` field, instead of being broken out into separate fields.

* **What is the new behavior (if this is a feature change)?**

This PR fixes the above behavior by breaking the information out into more fields, and it also adds a convenience field called `duration`, which is the timecode converted into milliseconds, accounting for frame time:

```
response: {
  "slotId": 1,
  "clips": [
    {
      "clipId": "1",
      "name": "Blackmagic HyperDeck Studio Mini[0000].mov",
      "codec": "QuickTimeProRes",
      "format": "1080i50",
      "timecode": "03:43:22:03",
      "duration": 13402060
    },
    {
      "clipId": "2",
      "name": "Blackmagic HyperDeck Studio Mini[0001].mov",
      "codec": "QuickTimeProRes",
      "format": "1080i50",
      "timecode": "00:35:07:21",
      "duration": 2107420
    },
    {
      "clipId": "3",
      "name": "HyperDeck_0006.mov",
      "codec": "QuickTimeProRes",
      "format": "1080i50",
      "timecode": "00:00:19:08",
      "duration": 19160
    },
    {
      "clipId": "4",
      "name": "HyperDeck_0007.mov",
      "codec": "QuickTimeProRes",
      "format": "1080i50",
      "timecode": "00:00:04:12",
      "duration": 4240
    },
    {
      "clipId": "5",
      "name": "HyperDeck_0008.mov",
      "codec": "QuickTimeProRes",
      "format": "1080i50",
      "timecode": "00:00:05:16",
      "duration": 5320
    },
    {
      "clipId": "6",
      "name": "HyperDeck_0009.mov",
      "codec": "QuickTimeProRes",
      "format": "1080i50",
      "timecode": "00:00:00:24",
      "duration": 480
    },
    {
      "clipId": "7",
      "name": "HyperDeck_0010.mov",
      "codec": "QuickTimeProRes",
      "format": "1080i50",
      "timecode": "00:00:09:13",
      "duration": 9260
    },
    {
      "clipId": "8",
      "name": "HyperDeck_0011.mov",
      "codec": "QuickTimeProRes",
      "format": "1080i50",
      "timecode": "00:09:13:11",
      "duration": 553220
    },
    {
      "clipId": "9",
      "name": "HyperDeck_0012.mov",
      "codec": "QuickTimeProRes",
      "format": "1080i50",
      "timecode": "00:00:14:11",
      "duration": 14220
    },
    {
      "clipId": "10",
      "name": "HyperDeck_0013.mov",
      "codec": "QuickTimeProRes",
      "format": "1080i50",
      "timecode": "00:10:50:17",
      "duration": 650340
    }
  ]
}
```

* **Other information**:

Tested against a Hyperdeck Shuttle HD.
